### PR TITLE
Add support for shairport sync metadata pipe

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update && sudo apt install python3 python3-pip
-        pip3 install flake8 check-manifest twine pylint python-mpv python-mpd2 musicbrainzngs
+        pip3 install flake8 check-manifest twine pylint python-mpv python-mpd2 musicbrainzngs untangle
     - name: Flake8
       run: |
         flake8 pidi setup.py --ignore E501

--- a/pidi/__main__.py
+++ b/pidi/__main__.py
@@ -52,14 +52,6 @@ def get_args(display_types, client_types):
     arg.add_argument("--version", action="store_true",
                      help="Print \"pidi\" version.")
 
-    arg.add_argument("--port",
-                     help="Use a custom mpd port.",
-                     default=6600)
-
-    arg.add_argument("--server",
-                     help="Use a remote server instead of localhost.",
-                     default="localhost")
-
     arg.add_argument("--no_display",
                      action="store_true",
                      help="Only download album art, don't display.")
@@ -116,7 +108,7 @@ def main():
 
     display = display_types[args.display](args)
 
-    client = client_types[args.client](args.port, args.server)
+    client = client_types[args.client](args)
 
     last_track = ''
     last_update = 0
@@ -132,10 +124,15 @@ def main():
                 title = currentsong.get('title', 'Untitled')
                 artist = currentsong.get('artist', 'No Artist')
                 album = currentsong.get('album', title)
+
                 current_track = f"{title} - {artist}, {album}"
 
                 if current_track != last_track:
                     print(f"pidi: got new track: {current_track}")
+
+                get_art = current_track != last_track or getattr(client, "pending_art", False)
+
+                if get_art:
                     client.get_art(args.cache_dir, args.size)
                     display.update_album_art(args.cache_dir / "current.jpg")
                     last_track = current_track

--- a/pidi/client.py
+++ b/pidi/client.py
@@ -77,7 +77,7 @@ class ClientShairportSync():
 
     def get_art(self, cache_dir, size):
         """Get the album art."""
-        if self.album_art == "":
+        if self.album_art == "" or self.album_art is None:
             util.bytes_to_file(util.default_album_art(), cache_dir / "current.jpg")
             return
     
@@ -122,21 +122,19 @@ class ClientShairportSync():
             self.album_art = data
 
         if (dtype, dcode) == ("core", "asal"):  # Album
-            self.album = data.decode("utf-8")
+            self.album = "" if data is None else data.decode("utf-8")
 
         if (dtype, dcode) == ("core", "asar"):  # Artist
-            self.artist = data.decode("utf-8")
+            self.artist = "" if data is None else data.decode("utf-8")
 
         if (dtype, dcode) == ("core", "minm"):  # Song Name / Item
-            self.title = data.decode("utf-8")
+            self.title = "" if data is None else data.decode("utf-8")
 
         if (dtype, dcode) == ("ssnc", "prsm"):
             self.state = "play"
 
         if (dtype, dcode) == ("ssnc", "pend"):
             self.state = "stop"
-
-        print(dtype, dcode)
 
 
 class ClientMPD():

--- a/pidi/client.py
+++ b/pidi/client.py
@@ -1,10 +1,14 @@
 """
 Get song info.
 """
+import time
 import shutil
 from pkg_resources import iter_entry_points
 
 import mpd
+import untangle
+from base64 import decodebytes
+from .fifo import FIFO
 
 from . import brainz
 from . import util
@@ -13,7 +17,8 @@ from . import util
 def get_client_types():
     """Enumerate the pidi.plugin.client entry point and return installed client types."""
     client_types = {
-        'mpd': ClientMPD
+        'mpd': ClientMPD,
+        'ssnc': ClientShairportSync
     }
 
     for entry_point in iter_entry_points("pidi.plugin.client"):
@@ -29,16 +34,121 @@ def get_client_types():
     return client_types
 
 
+class ClientShairportSync():
+    def __init__(self, args):
+        self.title = ""
+        self.artist = ""
+        self.album = ""
+        self.time = 100
+        self.state = ""
+        self.volume = 0
+        self.random = 0
+        self.repeat = 0
+        self.shuffle = 0
+        self.album_art = ""
+        self.pending_art = False
+
+        self._update_pending = False
+
+        self.fifo = FIFO(args.pipe, eol="</item>", skip_create=True)
+
+    def add_args(argparse):  # pylint: disable=no-self-argument
+        argparse.add_argument("--pipe",
+                    help="Pipe file for shairport sync metadata.",
+                    default="/tmp/shairport-sync-metadata")
+
+    def status(self):
+        return {
+            "random": self.random,
+            "repeat": self.repeat,
+            "state": self.state,
+            "volume": self.volume,
+            "shuffle": self.shuffle
+        }
+
+    def currentsong(self):
+        self._update_pending = False
+        return {
+            "title": self.title,
+            "artist": self.artist,
+            "album": self.album,
+            "time": self.time
+        }
+
+    def get_art(self, cache_dir, size):
+        """Get the album art."""
+        if self.album_art == "":
+            util.bytes_to_file(util.default_album_art(), cache_dir / "current.jpg")
+            return
+    
+        util.bytes_to_file(self.album_art, cache_dir / "current.jpg")
+
+        self.pending_art = False
+
+    def update_pending(self):
+        attempts = 0
+        while True:
+            data = self.fifo.read()
+            if data is None or len(data) == 0:
+                attempts += 1
+                if attempts > 100:
+                    return
+            else:
+                self._parse_data(data)
+                self._update_pending = True
+    
+        return self._update_pending
+
+    def _parse_data(self, data):
+        try:
+            data = untangle.parse(data)
+        except:
+            print("ClientShairportSync: failed to parse XML")
+            return
+
+        dtype = bytes.fromhex(data.item.type.cdata).decode("ascii")
+        dcode = bytes.fromhex(data.item.code.cdata).decode("ascii")
+        
+        data = getattr(data.item, "data", None)
+
+        if data is not None:
+            encoding = data["encoding"]
+            data = data.cdata
+            if encoding == "base64":
+                data = decodebytes(data.encode("ascii"))
+
+        if (dtype, dcode) == ("ssnc", "PICT"):
+            self.pending_art = True
+            self.album_art = data
+
+        if (dtype, dcode) == ("core", "asal"):  # Album
+            self.album = data.decode("utf-8")
+
+        if (dtype, dcode) == ("core", "asar"):  # Artist
+            self.artist = data.decode("utf-8")
+
+        if (dtype, dcode) == ("core", "minm"):  # Song Name / Item
+            self.title = data.decode("utf-8")
+
+        if (dtype, dcode) == ("ssnc", "prsm"):
+            self.state = "play"
+
+        if (dtype, dcode) == ("ssnc", "pend"):
+            self.state = "stop"
+
+        print(dtype, dcode)
+
+
 class ClientMPD():
     """Client for MPD and MPD-like (such as Mopidy) music back-ends."""
-    def __init__(self, port=6600, server="localhost"):
+    def __init__(self, args=None):
         """Initialize mpd."""
         self._client = mpd.MPDClient()
         self._current = None
 
         try:
-            print(f"Connecting to mpd {server}:{port}")
-            self._client.connect(server, port)
+            print(f"Connecting to mpd {args.server}:{args.port}")
+            self._client.connect(args.server, args.port)
             print("Connected!")
 
         except ConnectionRefusedError as exc:
@@ -46,6 +156,13 @@ class ClientMPD():
 
     def add_args(argparse):  # pylint: disable=no-self-argument
         """Expand argparse instance with client-specific args."""
+        argparse.add_argument("--port",
+                    help="Use a custom mpd port.",
+                    default=6600)
+
+        argparse.add_argument("--server",
+                    help="Use a remote server instead of localhost.",
+                    default="localhost")
 
     def currentsong(self):
         """Return current song details."""

--- a/pidi/fifo.py
+++ b/pidi/fifo.py
@@ -1,0 +1,53 @@
+import os
+import select
+
+
+class FIFO:
+    def __init__(self, fifo_name, eol="\n", skip_create=False):
+        self.fifo_name = fifo_name
+        self.eol = eol
+
+        if not skip_create:
+            self._create()
+
+        self._f = None
+        self._buf = ""
+
+    def _create(self):
+        try:
+            os.unlink(self.fifo_name)
+        except (IOError, OSError):
+            pass
+
+        os.mkfifo(self.fifo_name)
+        os.chmod(self.fifo_name, 0o777)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._f is not None:
+            os.close(self._f)
+            self._f = None
+
+    def read(self):
+        if self._f is None:
+            self._f = os.open(self.fifo_name, os.O_RDONLY | os.O_NONBLOCK)
+
+        # Check for inbound command
+        r, w, e = select.select([self._f], [], [], 0)
+        if self._f in r:
+            while True:
+                try:
+                    char = os.read(self._f, 1).decode("UTF-8")
+                except BlockingIOError:
+                    return None
+                if len(char) == 0:
+                    return None
+                self._buf += char
+                if self._buf.endswith(self.eol):
+                    buf = self._buf
+                    self._buf = ""
+                    return buf.strip()
+        else:
+            return None

--- a/pidi/fifo.py
+++ b/pidi/fifo.py
@@ -1,8 +1,14 @@
+"""
+Basic fifo handler.
+"""
 import os
 import select
 
 
 class FIFO:
+    """
+    Basic fifo handler.
+    """
     def __init__(self, fifo_name, eol="\n", skip_create=False):
         self.fifo_name = fifo_name
         self.eol = eol
@@ -31,12 +37,13 @@ class FIFO:
             self._f = None
 
     def read(self):
+        """Read data from the fifo."""
         if self._f is None:
             self._f = os.open(self.fifo_name, os.O_RDONLY | os.O_NONBLOCK)
 
         # Check for inbound command
-        r, w, e = select.select([self._f], [], [], 0)
-        if self._f in r:
+        fifos, _, _ = select.select([self._f], [], [], 0)
+        if self._f in fifos:
             while True:
                 try:
                     char = os.read(self._f, 1).decode("UTF-8")

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ packages = find:
 install_requires =
     musicbrainzngs
     python-mpd2
+    untangle
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This changeset adds support for Shairport Sync Metadata pipe into PiDi directly. The setup is simple enough, common enough and relies upon few dependencies that it might as well just be part of the core application.

## Dependencies

There seems to be a bug with enabling metadata pipe on shairport sync at the moment, see: https://github.com/mikebrady/shairport-sync/issues/1066 for an interim patch if you want to test this code.

Shairport Sync for PiDi requires an unpublished fix to the `pidi-display-pil` plugin which you must install from here: https://github.com/pimoroni/pidi-plugins

If you're testing on a Pirate Audio board you should also install `pidi-display-st7789`

Run with `pidi --client ssnc --display st7789`

## Known Issues

Some testing is required- known issues:

* Transport controls and volume are displayed but not currently supported, progress support *might* be possible. PiDi-Spotify manages it, but is not part of the PiDi application so it can use some ugly hacks
* Album art crossfade is buggy, sometimes showing the old art superimposed over the new (or vice versa) I think I ran into this with PiDi-Spotify and fixed it somehow.

## Thoughts

Right now PiDi only supports *ONE* source and *ONE* sink, I'm not sure this could/should ever change due to complexity but it's clear that people use multiple audio streaming solutions on the same Pi and might prefer a more modular approach to updating art.

Some wider discussion about how track metadata should be aggregated across platforms and displayed on different displays is probably warranted. I'm obviously bought into PiDi but I don't think it's *the* answer.